### PR TITLE
Fix import for `migrate!` function

### DIFF
--- a/src/cpg_dynam.jl
+++ b/src/cpg_dynam.jl
@@ -13,7 +13,7 @@ import Catlab.WiringDiagrams: oapply
 import ..UWDDynam: nstates, nports, eval_dynamics, euler_approx
 import ..DWDDynam: AbstractMachine, ContinuousMachine, DiscreteMachine, 
 ninputs, noutputs
-import Catlab.CategoricalAlgebra.CSets: migrate!
+import Catlab.CategoricalAlgebra: migrate!
 
 using Base.Iterators
 import Base: show, eltype


### PR DESCRIPTION
Looser import to avoid breakage from https://github.com/AlgebraicJulia/Catlab.jl/pull/433.