### PR TITLE
ehn: update signature of readout function for machines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 /notebooks/.ipynb_checkpoints
 /notebooks/images/*
 
-/docs/src/* 
+/docs/src/examples/*
+/docs/build/*

--- a/docs/examples/CPG_examples.jl
+++ b/docs/examples/CPG_examples.jl
@@ -45,8 +45,8 @@ sirfuncm = (u,x,p,t)->[-β*u[1]*u[2] - α₁*(u[1]-(x[1]+x[3])/2),
                         μ*u[2]
                        ]
 
-boundary  = ContinuousMachine{Float64}(2,3,sirfuncb, u->u[1:2])
-middle    = ContinuousMachine{Float64}(4,3, sirfuncm, u->u[[1,2,1,2]])
+boundary  = ContinuousMachine{Float64}(2,3,sirfuncb, (u,p,t)->u[1:2])
+middle    = ContinuousMachine{Float64}(4,3, sirfuncm, (u,p,t)->u[[1,2,1,2]])
 
 ## Compose
 threecity = oapply(d₂, [boundary,middle,boundary])
@@ -91,8 +91,9 @@ n = 100
 row = apex(gridpath(n, 1))
 
 ## Define the primitive system which will be repeated for each cell
-rule = DiscreteMachine{Bool}(2, 1, 2, (u, x, p, t)->Rule(p)(x[2], u[1], x[1]), 
-            u->[u[1], u[1]])
+rule = DiscreteMachine{Bool}(2, 1, 2, 
+            (u, x, p, t)->Rule(p)(x[2], u[1], x[1]), 
+            (u,p,t)->[u[1], u[1]])
 
 ## Compose
 automaton = oapply(row, rule)

--- a/docs/examples/Cyber-Physical.jl
+++ b/docs/examples/Cyber-Physical.jl
@@ -67,9 +67,9 @@ function 𝗟(𝐖)
                              q = -0.013*u[1] - 0.426*u[2] + 0.0203*x[1],
                              θ =  56.7*u[2]              );
 
-    u_𝐿(u) = [ u[1] ];  # outputs sl
-    u_𝐶(u) = [ u[1] ];  # outputs sc
-    u_𝐷(u) = [ u[3] ];  # outputs θ
+    u_𝐿(u,p,t) = [ u[1] ];  # outputs sl
+    u_𝐶(u,p,t) = [ u[1] ];  # outputs sc
+    u_𝐷(u,p,t) = [ u[3] ];  # outputs θ
 
     return oapply(𝐖,
                   Dict(:sensor     => ContinuousMachine{Float64}(2, 1, 1, 𝐿, u_𝐿),

--- a/docs/examples/Ecosystem.jl
+++ b/docs/examples/Ecosystem.jl
@@ -148,9 +148,9 @@ dotfish(f, x, p, t) = [p.αfish*f[1] - p.βfishF*x[1]*f[1]]
 dotFISH(F, x, p, t) = [p.γfishF*x[1]*F[1] - p.δF*F[1] - p.βFs*x[2]*F[1]]
 dotsharks(s, x, p, t) = [p.γFs*s[1]*x[1]-p.δs*s[1]]
 
-fish   = ContinuousMachine{Float64}(1,1,1, dotfish,   f->f)
-FISH   = ContinuousMachine{Float64}(2,1,1, dotFISH,   F->F)
-sharks = ContinuousMachine{Float64}(1,1,1, dotsharks, s->s)
+fish   = ContinuousMachine{Float64}(1,1,1, dotfish,   (f,p,t)->f)
+FISH   = ContinuousMachine{Float64}(2,1,1, dotFISH,   (F,p,t)->F)
+sharks = ContinuousMachine{Float64}(1,1,1, dotsharks, (s,p,t)->s)
 
 # We compose these machines by (1) sending the output of the big fish machine as the input to both the little fish and shark machines and (2) sending the output of the little fish and shark machines as the inputs to the big fish machine.
 # The syntax for this directed composition is given by a directed wiring diagram.

--- a/docs/examples/Lotka-Volterra.jl
+++ b/docs/examples/Lotka-Volterra.jl
@@ -78,8 +78,8 @@ using AlgebraicDynamics.DWDDynam
 dotr(u, x, p, t) = [p.α*u[1] - p.β*u[1]*x[1]]
 dotf(u, x, p, t) = [p.γ*u[1]*x[1] - p.δ*u[1]]
 
-rabbit = ContinuousMachine{Float64}(1,1,1, dotr, u -> u)
-fox    = ContinuousMachine{Float64}(1,1,1, dotf, u -> u)
+rabbit = ContinuousMachine{Float64}(1,1,1, dotr, (u, p, t) -> u)
+fox    = ContinuousMachine{Float64}(1,1,1, dotf, (u, p, t) -> u)
 
 ## Define the composition pattern
 rabbitfox_pattern = WiringDiagram([], [])

--- a/src/cpg_dynam.jl
+++ b/src/cpg_dynam.jl
@@ -45,8 +45,8 @@ colimitmap!(f::Function, output, C::Colimit, input) = begin
     return output
 end
 
-@inline fillreadouts!(y, d, xs, Ports, statefun) = colimitmap!(y, Ports, xs) do i,x
-    return x.readout(statefun(i))
+@inline fillreadouts!(y, d, xs, Ports, statefun, p, t) = colimitmap!(y, Ports, xs) do i,x
+    return x.readout(statefun(i), p, t)
 end
 
 @inline fillstates!(y, d, xs, States, statefun, inputfun, p, t) = colimitmap!(y, States, xs) do i, x
@@ -90,7 +90,7 @@ function oapply(d::OpenCPortGraph, xs::Vector{Machine}) where {T, Machine<:Abstr
         # length(p) == length(d[:, :con]) || error("Expected $(length(d[:, :con])) parameters, have $(length(p))")
         statefun(b) = state(u,b)
         inputfun(b) = readins[incident(d, b, :box)]
-        fillreadouts!(readouts, d, xs, Ports, statefun)
+        fillreadouts!(readouts, d, xs, Ports, statefun, p, t)
         # communicate readouts to the ports at the other end of the wires, external connections directly fill ports
         readins .= 0 
         fillreadins!(readins, d, readouts)
@@ -98,9 +98,9 @@ function oapply(d::OpenCPortGraph, xs::Vector{Machine}) where {T, Machine<:Abstr
         fillstates!(ϕ, d, xs, S, statefun, inputfun, p, t)
         return ϕ
     end
-    function readout(u::AbstractVector)
+    function readout(u::AbstractVector, p, t)
         statefun(b) = state(u,b)
-        fillreadouts!(readouts, d, xs, Ports, statefun)
+        fillreadouts!(readouts, d, xs, Ports, statefun, p, t)
         return readouts[d[:, :con]]
     end
     return Machine( nparts(d, :OuterPort), apex(S).set, v, readout)

--- a/src/dwd_dynam.jl
+++ b/src/dwd_dynam.jl
@@ -53,6 +53,11 @@ struct DiscreteMachine{T} <: AbstractMachine{T}
     dynamics::Function
     readout::Function
 end
+
+ContinuousMachine{T}(ninputs::Int, nstates::Int, dynamics) where T  = 
+    ContinuousMachine{T}(ninputs, nstates, nstates, dynamics, (u,p,t) -> u)
+DiscreteMachine{T}(ninputs::Int, nstates::Int, dynamics) where T  = 
+    DiscreteMachine{T}(ninputs, nstates, nstates, dynamics, (u,p,t) -> u)
   
 show(io::IO, vf::ContinuousMachine) = print("ContinuousMachine(ℝ^$(vf.nstates) × ℝ^$(vf.ninputs) → ℝ^$(vf.nstates))")
 show(io::IO, vf::DiscreteMachine) = print("DiscreteMachine(ℝ^$(vf.nstates) × ℝ^$(vf.ninputs) → ℝ^$(vf.nstates))")
@@ -61,8 +66,8 @@ eltype(m::AbstractMachine{T}) where T = T
 nstates(f::AbstractMachine) = f.nstates
 ninputs(f::AbstractMachine) = f.ninputs
 noutputs(f::AbstractMachine) = f.noutputs
-readout(f::AbstractMachine, u::AbstractVector) = f.readout(u)
-readout(f::AbstractMachine, u::FinDomFunction) = readout(f, collect(u))
+readout(f::AbstractMachine, u::AbstractVector, p = nothing, t = 0) = f.readout(u, p, t)
+readout(f::AbstractMachine, u::FinDomFunction, args...) = readout(f, collect(u), args...)
 
 """    eval_dynamics(m::AbstractMachine, u::AbstractVector, xs:AbstractVector, p, t)
 
@@ -201,7 +206,7 @@ function oapply(d::WiringDiagram, ms::Vector{Machine}) where {T, Machine <: Abst
     v = (u::AbstractVector, xs::AbstractVector, p, t::Real) -> begin 
         states = destruct(S, u) # a list of the states by box
         readouts = map(enumerate(ms)) do (i, m) 
-            readout(m, states[i])
+            readout(m, states[i], p, t)
         end 
         readins = zeros(T, length(apex(Inputs)))
 
@@ -217,10 +222,10 @@ function oapply(d::WiringDiagram, ms::Vector{Machine}) where {T, Machine <: Abst
         end)
     end
 
-    function r(u::AbstractVector)
+    function r(u::AbstractVector, p, t)
         states = destruct(S, u)
         readouts = map(enumerate(ms)) do (i, m)
-            readout(m, states[i])
+            readout(m, states[i], p, t)
         end 
         
         outs = zeros(T, length(output_ports(d)))

--- a/test/cpg_dynam.jl
+++ b/test/cpg_dynam.jl
@@ -27,8 +27,8 @@ end
 
 d = barbell(2)
 xs = [
-    ContinuousMachine{Float64}(2,2,(u, x, p, t)->[x[1]*u[1], x[2]*u[2]], u->u),
-    ContinuousMachine{Float64}(2,2,(u, x, p, t)->[1/x[1]*u[1], -x[2]*u[2]], u->u)
+    ContinuousMachine{Float64}(2,2,(u, x, p, t)->[x[1]*u[1], x[2]*u[2]], (u,p,t)->u),
+    ContinuousMachine{Float64}(2,2,(u, x, p, t)->[1/x[1]*u[1], -x[2]*u[2]], (u,p,t)->u)
 ]
 h = 0.1
 u₀ = ones(Float64, 4)
@@ -80,8 +80,8 @@ sirfuncm = (u,x,p,t)->[-β*u[1]*u[2] - α₁*(u[1]-(x[1]+x[3])/2),
                         ]
 
 
-boundary  = ContinuousMachine{Float64}(2,3,sirfuncb, u->u[1:2])
-middle    = ContinuousMachine{Float64}(4,3, sirfuncm, u->u[[1,2,1,2]])
+boundary  = ContinuousMachine{Float64}(2,3,sirfuncb, (u,p,t)->u[1:2])
+middle    = ContinuousMachine{Float64}(4,3, sirfuncm, (u,p,t)->u[[1,2,1,2]])
 threecity = oapply(d₂, [boundary,middle,boundary])
 
 # println("Simulating 3 city")
@@ -142,12 +142,12 @@ g3 = migrate!(Graph(), pg3)
 
 
 α₁ = 1
-fm = ContinuousMachine{Float64}(4, 1, (u,x,p,t) -> α₁ * (sum(x) .- u .* length(x)), u->repeated(u[1], 4))
-fl = ContinuousMachine{Float64}(3, 1, (u,x,p,t) -> α₁ * (sum(x) .- u .* length(x)), u->repeated(u[1], 3))
-fr = ContinuousMachine{Float64}(3, 1, (u,x,p,t) -> α₁ * (sum(x) .- u .* length(x)), u->repeated(u[1], 3))
-ft = ContinuousMachine{Float64}(3, 1, (u,x,p,t) -> α₁ * (sum(x) .- u .* length(x)), u->repeated(u[1], 3))
-fb = ContinuousMachine{Float64}(3, 1, (u,x,p,t) -> α₁ * (sum(x) .- u .* length(x)), u->repeated(u[1], 3))
-fc = ContinuousMachine{Float64}(2, 1, (u,x,p,t) -> α₁ * (sum(x) .- u .* length(x)), u->repeated(u[1], 2))
+fm = ContinuousMachine{Float64}(4, 1, (u,x,p,t) -> α₁ * (sum(x) .- u .* length(x)), (u,p,t)->repeated(u[1], 4))
+fl = ContinuousMachine{Float64}(3, 1, (u,x,p,t) -> α₁ * (sum(x) .- u .* length(x)), (u,p,t)->repeated(u[1], 3))
+fr = ContinuousMachine{Float64}(3, 1, (u,x,p,t) -> α₁ * (sum(x) .- u .* length(x)), (u,p,t)->repeated(u[1], 3))
+ft = ContinuousMachine{Float64}(3, 1, (u,x,p,t) -> α₁ * (sum(x) .- u .* length(x)), (u,p,t)->repeated(u[1], 3))
+fb = ContinuousMachine{Float64}(3, 1, (u,x,p,t) -> α₁ * (sum(x) .- u .* length(x)), (u,p,t)->repeated(u[1], 3))
+fc = ContinuousMachine{Float64}(2, 1, (u,x,p,t) -> α₁ * (sum(x) .- u .* length(x)), (u,p,t)->repeated(u[1], 2))
 
 @test eval_dynamics(ft, ones(1), ones(3), nothing, 0.0) == zeros(1)
 f₁ = oapply(gl, [fc, fl, fc])
@@ -207,9 +207,9 @@ end
 advecdiffuse(α₁, α₂) = begin
     diffop(u,p,t) = α₁ .* (sum(p) .- u .* length(p))
     advop(u,p,t)  = α₂ .* (p[end] .- u)
-    ft = ContinuousMachine{Float64}(3, 1, (u,p,q,t) -> diffop(u,p,u) .+ advop(u,p,t), u->repeated(u[1], 3))
-    fm = ContinuousMachine{Float64}(4, 1, (u,p,q,t) -> diffop(u,p,u) .+ advop(u,p,t), u->repeated(u[1], 4))
-    fb = ContinuousMachine{Float64}(3, 1, (u,p,q,t) -> diffop(u,p,u) .+ advop(u,p,t), u->repeated(u[1], 3))
+    ft = ContinuousMachine{Float64}(3, 1, (u,p,q,t) -> diffop(u,p,u) .+ advop(u,p,t), (u,p,t)->repeated(u[1], 3))
+    fm = ContinuousMachine{Float64}(4, 1, (u,p,q,t) -> diffop(u,p,u) .+ advop(u,p,t), (u,p,t)->repeated(u[1], 4))
+    fb = ContinuousMachine{Float64}(3, 1, (u,p,q,t) -> diffop(u,p,u) .+ advop(u,p,t), (u,p,t)->repeated(u[1], 3))
     return ft, fm, fb
 end
 
@@ -245,9 +245,9 @@ end
 RDA(α₀, α₁, α₂) = begin
     diffop(u,p,t) = α₁ .* (sum(p) .- u .* length(p))
     advop(u,p,t)  = α₂ .* (p[end] .- u)
-    ft = ContinuousMachine{Float64}(3, 1, (u,p,q,t) -> α₀ .* u .+ diffop(u,p,u) .+ advop(u,p,t), u->repeated(u[1], 3))
-    fm = ContinuousMachine{Float64}(4, 1, (u,p,q,t) -> α₀ .* u .+ diffop(u,p,u) .+ advop(u,p,t), u->repeated(u[1], 4))
-    fb = ContinuousMachine{Float64}(3, 1, (u,p,q,t) -> α₀ .* u .+ diffop(u,p,u) .+ advop(u,p,t), u->repeated(u[1], 3))
+    ft = ContinuousMachine{Float64}(3, 1, (u,p,q,t) -> α₀ .* u .+ diffop(u,p,u) .+ advop(u,p,t), (u,p,t)->repeated(u[1], 3))
+    fm = ContinuousMachine{Float64}(4, 1, (u,p,q,t) -> α₀ .* u .+ diffop(u,p,u) .+ advop(u,p,t), (u,p,t)->repeated(u[1], 4))
+    fb = ContinuousMachine{Float64}(3, 1, (u,p,q,t) -> α₀ .* u .+ diffop(u,p,u) .+ advop(u,p,t), (u,p,t)->repeated(u[1], 3))
     return ft, fm, fb
 end
 

--- a/test/dwd_dynam.jl
+++ b/test/dwd_dynam.jl
@@ -5,7 +5,7 @@ using Test
 # Identity 
 A = [:A]
 uf(u, x, p, t) = [x[1] - u[1]]
-rf(u) = u
+rf(u, args...) = u
 mf = ContinuousMachine{Float64}(1,1,1, uf, rf)
 
 f = Box(:f, A, A)
@@ -111,14 +111,14 @@ add_wires!(d, Pair[
 
 m1 = ContinuousMachine{Float64}(2,1,1, 
         (u, x, p, t) -> [x[1] * x[2]  - u[1]], 
-        u -> 2*u)
+        (u,p,t) -> 2*u)
 m2 = ContinuousMachine{Float64}(1, 2, 2, 
         (u, x, p, t) -> [u[1]*u[2], x[1]^2*u[2]], 
-        u -> u)
+        (u,p,t) -> u)
 
 m3 = ContinuousMachine{Float64}(1,2,1, 
         (u, x, p, t) -> [u[1]^2 - x[1], u[2] - u[1]], 
-        u -> [u[1] + u[2]])
+        (u,p,t) -> [u[1] + u[2]])
 
 xs = Dict(:f => m1, :g => m2, :h => m3, :j => mf)
 m = oapply(d, xs)

--- a/test/trajectories.jl
+++ b/test/trajectories.jl
@@ -70,7 +70,7 @@ end
 
 # Machine tests
 uf(u, x, p, t) = [x[1] - u[1]*x[2]]
-rf(u) = u
+rf(u,p,t) = u
 u0 = [1.0]
 m = ContinuousMachine{Any}(2,1, 1, uf, rf)
 xs = [t -> 1, t -> 1]
@@ -104,7 +104,7 @@ t = trajectory(dds, 100)
 
 # machines - oapply
 uf(u, x, p, t) = [x[1] - u[1], 0.0]
-rf(u) = u
+rf(u,p,t) = u
 mf = ContinuousMachine{Float64}(2,2,2, uf, rf)
 
 d_id = singleton_diagram(Box(:f, [:A, :A], [:A, :A]))
@@ -158,8 +158,8 @@ dds = DiscreteDynamicalSystem(lv_discrete, u0, params)
 dotr(u, x, p, t) = [p[1]*u[1] - p[2]*u[1]*x[1]]
 dotf(u, x, p, t) = [p[3]*u[1]*x[1] - p[4]*u[1]]
 
-rmachine = ContinuousMachine{Real}(1,1,1, dotr, r -> r)
-fmachine = ContinuousMachine{Real}(1,1,1, dotf, f -> f)
+rmachine = ContinuousMachine{Real}(1,1,1, dotr, (r,p,t) -> r)
+fmachine = ContinuousMachine{Real}(1,1,1, dotf, (f,p,t) -> f)
 
 rf_pattern = WiringDiagram([],[])
 boxr = add_box!(rf_pattern, Box(nothing, [nothing], [nothing]))
@@ -194,9 +194,9 @@ dotfish(f, x, p, t) = [p[1]*f[1] - p[2]*x[1]*f[1]]
 dotFISH(F, x, p, t) = [p[3]*x[1]*F[1] - p[4]*F[1] - p[5]*x[2]*F[1]]
 dotsharks(s, x, p, t) = [-p[7]*s[1] + p[6]*s[1]*x[1]]
 
-fish   = ContinuousMachine{Real}(1,1,1, dotfish,   f ->f)
-FISH   = ContinuousMachine{Real}(2,1,2, dotFISH,   F->[F[1], F[1]])
-sharks = ContinuousMachine{Real}(1,1,1, dotsharks, s->s)
+fish   = ContinuousMachine{Real}(1,1,1, dotfish,   (f,p,t) ->f)
+FISH   = ContinuousMachine{Real}(2,1,2, dotFISH,   (F,p,t)->[F[1], F[1]])
+sharks = ContinuousMachine{Real}(1,1,1, dotsharks, (s,p,t)->s)
 
 ocean_pat = WiringDiagram([], [])
 boxf = add_box!(ocean_pat, Box(nothing, [nothing], [nothing]))


### PR DESCRIPTION
For `AbstractMachine`s change the signature of the readout map to match the signature of the update function, i.e. the readout function is of the form `r(u,p,t)` and can depend on the parameters and time.

Fixes Issue #59. 