### PR TITLE
update docstrings for new readout signature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 
 /docs/src/examples/*
 /docs/build/*
+
+.vscode

--- a/src/dwd_dynam.jl
+++ b/src/dwd_dynam.jl
@@ -30,7 +30,7 @@ abstract type AbstractMachine{T} end
 
 An undirected open continuous system. The dynamics function `f` defines an ODE ``\\dot u(t) = f(u(t),x(t),p,t)`` where ``u`` is the state and ``x`` captures the exogenous variables.
 
-The readout function may only depend on the state, so it must be of the form ``r(u(t))``.
+The readout function may depend on the state, parameters, and time, so it must be of the form ``r(u,p,t)``.
 """
 struct ContinuousMachine{T} <: AbstractMachine{T}
     ninputs::Int
@@ -44,7 +44,7 @@ end
 
 A directed open discrete dynamical system. The dynamics function `f` defines a discrete update rule ``u_{n+1} = f(u_n, x_n, p, t)`` where ``u_n`` is the state and ``x_n`` is the value of the exogenous variables at the ``n``th time step.
 
-The readout function may only depend on the state, so it must be of the form ``r(u_n)``.
+The readout function may depend on the state, parameters, and time step, so it must be of the form ``r(u_n,p,n)``.
 """
 struct DiscreteMachine{T} <: AbstractMachine{T}
     ninputs::Int


### PR DESCRIPTION
This PR updates the docs for `DiscreteMachine` and `ContinuousMachine` to reflect the updated function signature for readouts here: https://github.com/AlgebraicJulia/AlgebraicDynamics.jl/pull/60