### PR TITLE
Fix compatibility issue with new version of CombinatorialSpaces

### DIFF
--- a/src/TontiDiagrams.jl
+++ b/src/TontiDiagrams.jl
@@ -7,14 +7,13 @@ simulation of physical systems through any traditional vectorfield solver.
 """
 
 module Tonti
-using Catlab.Present
-using Catlab.Theories
+using Catlab, Catlab.Theories
 using Catlab.CategoricalAlgebra
 using Catlab.CategoricalAlgebra.FinSets
 using Catlab.Programs
 using Catlab.WiringDiagrams
 using CombinatorialSpaces
-import CombinatorialSpaces.DualSimplicialSets: EmbeddedDeltaDualComplex2D, ⋆
+import CombinatorialSpaces: EmbeddedDeltaDualComplex2D, ⋆
 
 export TontiDiagram, AbstractTontiDiagram, addTransform!, addSpace!,
        addTime!, vectorfield, disj_union, gen_form, addBC!


### PR DESCRIPTION
It's also worth pointing out that the constructor added here is a type piracy from CombinatorialSpaces, but I'm not going to fix that right now.

```julia
EmbeddedDeltaDualComplex2D(d::EmbeddedDeltaSet2D) = ...
```