### PR TITLE
Dependent Directed Interface

### DIFF
--- a/src/dwd_dynam.jl
+++ b/src/dwd_dynam.jl
@@ -170,6 +170,12 @@ InstantaneousContinuousMachine{T}(ninputs, nstates, noutputs, dynamics, readout,
 InstantaneousContinuousMachine{T}(f::Function, ninputs::Int, noutputs::Int, dependency = nothing) where T = 
     InstantaneousContinuousMachine{T}(ninputs, 0, noutputs, (u,x,p,t)->T[], (u,x,p,t)->f(x), dependency)
 
+InstantaneousContinuousMachine(m::ContinuousMachine{T, I}) where {T, I<:DirectedInterface{T}} = 
+    ContinuousMachine{T}(InstantaneousDirectedInterface{T}(input_ports(m), output_ports(m), []), 
+                         ContinuousDirectedSystem{T}(nstates(m), dynamics(m), (u,x,p,t) -> readout(m, u, p, t))
+    )
+    
+
 
 """    DelayMachine{T}(ninputs, nstates, noutputs, f, r)
 
@@ -206,7 +212,10 @@ InstantaneousDelayMachine{T}(ninputs, nstates, noutputs, dynamics, readout, depe
 InstantaneousDelayMachine{T}(f::Function, ninputs::Int, noutputs::Int, dependency = nothing) where T = 
     InstantaneousDelayMachine{T}(ninputs, 0, noutputs, (u,x,p,t)->T[], (u,x,p,t)->f(x), dependency)
 
-
+InstantaneousDelayMachine(m::DelayMachine{T, I}) where {T, I<:DirectedInterface{T}} = 
+    DelayMachine{T}(InstantaneousDirectedInterface{T}(input_ports(m), output_ports(m), []), 
+                         DelayDirectedSystem{T}(nstates(m), dynamics(m), (u,x,p,t) -> readout(m, u, p, t))
+    )
   
 
 """    DiscreteMachine{T}(ninputs, nstates, noutputs, f, r)
@@ -244,6 +253,10 @@ InstantaneousDiscreteMachine{T}(ninputs, nstates, noutputs, dynamics, readout, d
 InstantaneousDiscreteMachine{T}(f::Function, ninputs::Int, noutputs::Int, dependency = nothing) where T = 
     InstantaneousDiscreteMachine{T}(ninputs, 0, noutputs, (u,x,p,t)->T[], (u,x,p,t)->f(x), dependency)
 
+InstantaneousDiscreteMachine(m::DiscreteMachine{T, I}) where {T, I<:DirectedInterface{T}} = 
+    DiscreteMachine{T}(InstantaneousDirectedInterface{T}(input_ports(m), output_ports(m), []), 
+                         DiscreteDirectedSystem{T}(nstates(m), dynamics(m), (u,x,p,t) -> readout(m, u, p, t))
+    )
 
 show(io::IO, vf::ContinuousMachine) = print(
     "ContinuousMachine(ℝ^$(nstates(vf)) × ℝ^$(ninputs(vf)) → ℝ^$(nstates(vf)))")

--- a/src/dwd_dynam.jl
+++ b/src/dwd_dynam.jl
@@ -46,11 +46,11 @@ struct InstantaneousDirectedInterface{T} <: AbstractDirectedInterface{T}
   dependency::Span # P_in <- R -> P_out
 end
 
-InstantaneousDirectedInterface{T}(input_ports::AbstractVector, output_ports::AbstractVector, dependency_pairs::AbstractVector{P}) where {T, P<:Pair} = 
+InstantaneousDirectedInterface{T}(input_ports::AbstractVector, output_ports::AbstractVector, dependency_pairs::AbstractVector) where {T} = 
   InstantaneousDirectedInterface{T}(input_ports, output_ports, 
     Span(
-      FinFunction(last.(dependency_pairs), length(dependency_pairs), length(input_ports)), 
-      FinFunction(first.(dependency_pairs), length(dependency_pairs), length(output_ports))
+      FinFunction(Array{Int}(last.(dependency_pairs)), length(dependency_pairs), length(input_ports)), 
+      FinFunction(Array{Int}(first.(dependency_pairs)), length(dependency_pairs), length(output_ports))
     ))
 
 InstantaneousDirectedInterface{T}(ninputs::Int, noutputs::Int, dependency) where {T} = 
@@ -669,13 +669,13 @@ function induced_dependency(d, dependency_colims)
     w.target.port 
   end
 
-  pb1 = pullback(FinFunction(pins, nv(h)), FinFunction(src(h), nv(h)))
-  pb2 = pullback(FinFunction(tgt(h), nv(h)), FinFunction(pouts, nv(h)))
+  pb1 = pullback(FinFunction(Array{Int}(pins), nv(h)), FinFunction(Array{Int}(src(h)), nv(h)))
+  pb2 = pullback(FinFunction(Array{Int}(tgt(h)), nv(h)), FinFunction(Array{Int}(pouts), nv(h)))
 
   pb = pullback(legs(pb1)[2], legs(pb2)[1])
 
-  p1 = FinFunction(qins, length(input_ports(d))) ∘ legs(pb1)[1] ∘ legs(pb)[1]
-  p2 = FinFunction(qouts, length(output_ports(d))) ∘ (legs(pb2)[2] ∘ legs(pb)[2])
+  p1 = FinFunction(Array{Int}(qins), length(input_ports(d))) ∘ legs(pb1)[1] ∘ legs(pb)[1]
+  p2 = FinFunction(Array{Int}(qouts), length(output_ports(d))) ∘ (legs(pb2)[2] ∘ legs(pb)[2])
 
   map(1:length(apex(pb))) do i 
     p2(i) => p1(i)

--- a/src/dwd_dynam.jl
+++ b/src/dwd_dynam.jl
@@ -170,7 +170,7 @@ InstantaneousContinuousMachine{T}(ninputs, nstates, noutputs, dynamics, readout,
 InstantaneousContinuousMachine{T}(f::Function, ninputs::Int, noutputs::Int, dependency = nothing) where T = 
     InstantaneousContinuousMachine{T}(ninputs, 0, noutputs, (u,x,p,t)->T[], (u,x,p,t)->f(x), dependency)
 
-InstantaneousContinuousMachine(m::ContinuousMachine{T, I}) where {T, I<:DirectedInterface{T}} = 
+InstantaneousContinuousMachine{T}(m::ContinuousMachine{T, I}) where {T, I<:DirectedInterface{T}} = 
     ContinuousMachine{T}(InstantaneousDirectedInterface{T}(input_ports(m), output_ports(m), []), 
                          ContinuousDirectedSystem{T}(nstates(m), dynamics(m), (u,x,p,t) -> readout(m, u, p, t))
     )

--- a/test/dwd_dynam.jl
+++ b/test/dwd_dynam.jl
@@ -126,7 +126,7 @@ add_wires!(d_big, Pair[
   end
 end
 
-@testset "Partially Dependent Systems" begin
+@testset "Instantaneous Machines" begin
   d = WiringDiagram([:X, :X], [:Y, :Z])
   b1 = add_box!(d, Box(:f, [:X], [:X]))
   b2 = add_box!(d, Box(:g, [:X, :X], [:X]))
@@ -139,8 +139,8 @@ end
     (b2, 1) => (output_id(d), 2)
   ])
 
-  f1 = DiscreteMachine{Float64}(1, 0, 1, (u,x,p,t)->u, (u,x,p,t)->x, [1=>1])
-  f2 = DiscreteMachine{Float64}(2, 1, 1, (u,x,p,t)->x[1]*u, (u,x,p,t)->[x[2]], [1=>2])
+  f1 = InstantaneousDiscreteMachine{Float64}(1, 0, 1, (u,x,p,t)->u, (u,x,p,t)->x, [1=>1])
+  f2 = InstantaneousDiscreteMachine{Float64}(2, 1, 1, (u,x,p,t)->x[1]*u, (u,x,p,t)->[x[2]], [1=>2])
   ms = [f1, f2]
 
   @test readout(f1, [], [2.0]) == [2.0]
@@ -154,7 +154,7 @@ end
   @test eval_dynamics(f, u, xs) == [5.0]
   @test dependency_pairs(f) == [1 => 1, 2 => 1]
 
-  f3 = DiscreteMachine{Float64}(x -> [sum(x)], 2, 1)
+  f3 = InstantaneousDiscreteMachine{Float64}(x -> [sum(x)], 2, 1)
   @test readout(f3, [], xs) == [5.0]
   @test eval_dynamics(f3, [], xs) == []
   @test dependency_pairs(f3) == [1 => 1, 1 => 2]
@@ -283,3 +283,5 @@ end
     @test eval_dynamics(m, vcat(u1, u2, u3), [x1, x2], nothing, 0) == vcat(x1, u2 + x1 + 2*u2 + u3, x2)
   end
 end
+
+

--- a/test/dwd_dynam.jl
+++ b/test/dwd_dynam.jl
@@ -182,6 +182,11 @@ end
   @test readout(g, u, xs) == [6.0]
   @test eval_dynamics(g, u, xs) == [5.0]
 
+  m = InstantaneousDiscreteMachine(DiscreteMachine{Int}(1, 1, 1, (u,x,p,t) -> x .+ u, (u,p,t) -> u))
+  @test length(dependency_pairs(m)) == 0
+  @test readout(m, [1], [2], nothing, 0) == [1]
+  @test eval_dynamics(m, [1], [2], nothing, 0) == [3]
+
   @testset "Fibonacci" begin 
     d = WiringDiagram([], [:N])
     b_plus = add_box!(d, Box(:plus, [:n, :n], [:n]))


### PR DESCRIPTION
Added a new interface `DirectedDependentInterface{T}` which has three components: `input_ports`, `output_ports`, and `dependency`. `dependency` represents the dependency relationships between output ports and input ports.

To compose machines with this interface, we must ensure that there is acyclic wiring pattern between equivalence classes of ports related by dependency.