### PR TITLE
pass vectors along wires for instantaneous machines 

### DIFF
--- a/examples/Ross-Macdonald.jl
+++ b/examples/Ross-Macdonald.jl
@@ -166,7 +166,7 @@ add_wires!(rmb, Pair[
 
 # These two terms are sent from the bloodmeal machine to the mosquito and human machines
 # via their input ports. Then the dynamical system filling the mosquito machine is
-# $\dot{Z} = a*\kappa*(e^{-gn} - Z) - gZ$ and $\dot{X} = bEIR(1-X) - rX$ is the dynamical system
+# $\dot{Z} = a\kappa (e^{-gn} - Z) - gZ$ and $\dot{X} = bEIR(1-X) - rX$ is the dynamical system
 # filling the human machine.
 
 to_graphviz(rmb)
@@ -270,6 +270,9 @@ plot(sol, label=["non-infectious mosquito population" "infectious mosquito popul
     xlabel = "time", ylabel = "proportion infectious",
     color = ["magenta" "red" "blue"]
 )
+N = length(sol)
+plot!(sol.t, fill(X̄, N), label = "human equilibrium", ls = :dash, lw = 2, color = "blue")
+plot!(sol.t, fill(Z̄, N), label = "infectious mosquito equilibrium", ls = :dash, lw = 2, color = "red")
 
 # While the equilibrium points of the two models are identical, they exhibit different dynamical behavior 
 # before settling down to equilibrium. Because models are often used to examine how the system may respond 

--- a/src/dwd_dynam.jl
+++ b/src/dwd_dynam.jl
@@ -329,18 +329,11 @@ readout(f::AbstractMachine, u::FinDomFunction, args...) = readout(f, collect(u),
 
 readout(m::Machine{T,I,S}, u::AbstractVector, x::AbstractVector, p=nothing, t=0) where {T, I<:AbstractInstantaneousDirectedInterface{T}, S} = 
   readout(m)(u,x,p,t)
-# readout(m::Machine{T,I,S}, u::AbstractVector, x::AbstractVector, p=nothing, t=0) where {T, I<:InstantaneousDirectedInterface{T}, S} = 
-#   readout(m)(u,x,p,t)
-# readout(m::Machine{T,I,S}, u::AbstractVector, x::AbstractVector, p=nothing, t=0) where {T, I<:InstantaneousDirectedVectorInterface, S} = 
-#   readout(m)(u,x,p,t)
 
 readout(f::DelayMachine{T,I}, u::AbstractVector, h=nothing, p = nothing, t = 0) where {T, I<:Union{DirectedInterface, DirectedVectorInterface}}= readout(f)(u, h, p, t)
 readout(m::DelayMachine{T,I}, u::AbstractVector, x::AbstractVector, h=nothing, p=nothing, t=0) where {T, I<:AbstractInstantaneousDirectedInterface} = 
   readout(m)(u,x,h,p,t)
-# readout(m::DelayMachine{T,I}, u::AbstractVector, x::AbstractVector, h=nothing, p=nothing, t=0) where {T, I<:InstantaneousDirectedInterface} = 
-#   readout(m)(u,x,h,p,t)
-# readout(m::DelayMachine{T,I}, u::AbstractVector, x::AbstractVector, h=nothing, p=nothing, t=0) where {T, I<:InstantaneousDirectedVectorInterface} = 
-#   readout(m)(u,x,h,p,t)
+  
 
 """    eval_dynamics(m::AbstractMachine, u::AbstractVector, x:AbstractVector{F}, p, t) where {F<:Function}
     eval_dynamics(m::AbstractMachine{T}, u::AbstractVector, x:AbstractVector{T}, p, t) where T

--- a/src/dwd_dynam.jl
+++ b/src/dwd_dynam.jl
@@ -39,8 +39,11 @@ end
 DirectedVectorInterface{T,N}(ninputs::Int, noutputs::Int) where {T,N} = 
     DirectedVectorInterface{T,N}(1:ninputs, 1:noutputs)
 
+# Instantaneous interfaces
+abstract type AbstractInstantaneousDirectedInterface{T} <: AbstractDirectedInterface{T} end 
+
 # InstantaneousDirectedInterface
-struct InstantaneousDirectedInterface{T} <: AbstractDirectedInterface{T} 
+struct InstantaneousDirectedInterface{T} <: AbstractInstantaneousDirectedInterface{T}
   input_ports::Vector 
   output_ports::Vector
   dependency::Span # P_in <- R -> P_out
@@ -65,13 +68,8 @@ InstantaneousDirectedInterface{T}(input_ports::AbstractVector, output_ports::Abs
     end...)
   )
 
-dependency(interface::InstantaneousDirectedInterface) = interface.dependency
-dependency_pairs(interface::InstantaneousDirectedInterface) = map(apex(dependency(interface))) do i 
-  legs(dependency(interface))[2](i) => legs(dependency(interface))[1](i)
-end |> sort
-
 # InstantaneousDirectedVectorInterface
-struct InstantaneousDirectedVectorInterface{T,N} <: AbstractDirectedInterface{T} 
+struct InstantaneousDirectedVectorInterface{T,N} <: AbstractInstantaneousDirectedInterface{T}
   input_ports::Vector 
   output_ports::Vector
   dependency::Span # P_in <- R -> P_out
@@ -96,8 +94,9 @@ InstantaneousDirectedVectorInterface{T,N}(input_ports::AbstractVector, output_po
     end...)
 )
 
-dependency(interface::InstantaneousDirectedVectorInterface) = interface.dependency
-dependency_pairs(interface::InstantaneousDirectedVectorInterface) = map(apex(dependency(interface))) do i 
+# get dependency
+dependency(interface::AbstractInstantaneousDirectedInterface) = interface.dependency
+dependency_pairs(interface::AbstractInstantaneousDirectedInterface) = map(apex(dependency(interface))) do i 
   legs(dependency(interface))[2](i) => legs(dependency(interface))[1](i)
 end |> sort
 

--- a/src/dwd_dynam.jl
+++ b/src/dwd_dynam.jl
@@ -199,11 +199,20 @@ ContinuousMachine{T,I}(ninputs, nstates, noutputs, dynamics, readout, dependency
 InstantaneousContinuousMachine{T}(ninputs, nstates, noutputs, dynamics, readout, dependency) where {T} = 
     ContinuousMachine{T, InstantaneousDirectedInterface{T}}(InstantaneousDirectedInterface{T}(ninputs, noutputs, dependency), ContinuousDirectedSystem{T}(nstates, dynamics, readout))
 
+InstantaneousContinuousMachine{T,I}(ninputs, nstates, noutputs, dynamics, readout, dependency) where {T,I<:InstantaneousDirectedInterface{T}} = 
+    ContinuousMachine{T,I}(I(ninputs, noutputs, dependency), ContinuousDirectedSystem{T}(nstates, dynamics, readout))
+
 InstantaneousContinuousMachine{T,N}(ninputs, nstates, noutputs, dynamics, readout, dependency) where {T,N} = 
     ContinuousMachine{T, InstantaneousDirectedVectorInterface{T,N}}(InstantaneousDirectedVectorInterface{T,N}(ninputs, noutputs, dependency), ContinuousDirectedSystem{T}(nstates, dynamics, readout))
 
-InstantaneousContinuousMachine{T, I}(f::Function, ninputs::Int, noutputs::Int, dependency = nothing) where {T,I} = 
-    InstantaneousContinuousMachine{T, I}(ninputs, 0, noutputs, (u,x,p,t)->T[], (u,x,p,t)->f(x), dependency)
+InstantaneousContinuousMachine{T}(f::Function, ninputs::Int, noutputs::Int, dependency = nothing) where {T} = 
+  ContinuousMachine{T,InstantaneousDirectedInterface{T}}(ninputs, 0, noutputs, (u,x,p,t)->f(x), (u,x,p,t)->T[], dependency)
+
+InstantaneousContinuousMachine{T,I}(f::Function, ninputs::Int, noutputs::Int, dependency = nothing) where {T,I<:AbstractInstantaneousDirectedInterface{T}} = 
+  ContinuousMachine{T,I}(ninputs, 0, noutputs, (u,x,p,t)->f(x), (u,x,p,t)->T[], dependency)
+
+InstantaneousContinuousMachine{T,N}(f::Function, ninputs::Int, noutputs::Int, dependency = nothing) where {T,N} = 
+  InstantaneousContinuousMachine{T,N}(ninputs, 0, noutputs, (u,x,p,t)->f(x), (u,x,p,t)->T[], dependency)
 
 InstantaneousContinuousMachine{T}(m::ContinuousMachine{T, I}) where {T, I<:DirectedInterface{T}} = 
     ContinuousMachine{T}(InstantaneousDirectedInterface{T}(input_ports(m), output_ports(m), []), 
@@ -221,7 +230,7 @@ The readout function `r` may depend on the state, history, parameters and time, 
 If it is left out, then ``r=u``.
 """
 const DelayMachine{T,I} = Machine{T, I, DelayDirectedSystem{T}}
-const InstantaneousDelayMachine{T, I} = Machine{T, I, DelayDirectedSystem{T}}
+const InstantaneousDelayMachine{T,I} = Machine{T, I, DelayDirectedSystem{T}}
 
 DelayMachine{T}(interface::I, system::DelayDirectedSystem{T}) where {T, I<:AbstractDirectedInterface} =
     DelayMachine{T, I}(interface, system)
@@ -244,15 +253,24 @@ DelayMachine{T,I}(ninputs, nstates, noutputs, dynamics, readout, dependency) whe
 InstantaneousDelayMachine{T}(ninputs, nstates, noutputs, dynamics, readout, dependency) where {T} = 
     DelayMachine{T, InstantaneousDirectedInterface{T}}(InstantaneousDirectedInterface{T}(ninputs, noutputs, dependency), DelayDirectedSystem{T}(nstates, dynamics, readout))
 
-InstantaneousDelayMachine{T,N}(ninputs, nstates, noutputs, dynamics, readout, dependency) where {T,N} = 
-    DelayMachine{T,InstantaneousDirectedVectorInterface{T,N}}(InstantaneousDirectedVectorInterface{T,N}(ninputs, noutputs, dependency), DelayDirectedSystem{T}(nstates, dynamics, readout))
+InstantaneousDelayMachine{T,I}(ninputs, nstates, noutputs, dynamics, readout, dependency) where {T,I<:InstantaneousDirectedInterface{T}} = 
+    DelayMachine{T,I}(I(ninputs, noutputs, dependency), DelayDirectedSystem{T}(nstates, dynamics, readout))
 
-InstantaneousDelayMachine{T, I}(f::Function, ninputs::Int, noutputs::Int, dependency = nothing) where {T,I} = 
-    InstantaneousDelayMachine{T, I}(ninputs, 0, noutputs, (u,x,p,t)->T[], (u,x,p,t)->f(x), dependency)
+InstantaneousDelayMachine{T,N}(ninputs, nstates, noutputs, dynamics, readout, dependency) where {T,N} = 
+    DelayMachine{T, InstantaneousDirectedVectorInterface{T,N}}(InstantaneousDirectedVectorInterface{T,N}(ninputs, noutputs, dependency), DelayDirectedSystem{T}(nstates, dynamics, readout))
+
+InstantaneousDelayMachine{T}(f::Function, ninputs::Int, noutputs::Int, dependency = nothing) where {T} = 
+    DelayMachine{T,InstantaneousDirectedInterface{T}}(ninputs, 0, noutputs, (u,x,h,p,t)->f(x), (u,x,h,p,t)->T[], dependency)
+
+InstantaneousDelayMachine{T,I}(f::Function, ninputs::Int, noutputs::Int, dependency = nothing) where {T,I<:AbstractInstantaneousDirectedInterface{T}} = 
+    DelayMachine{T,I}(ninputs, 0, noutputs, (u,x,h,p,t)->f(x), (u,x,h,p,t)->T[], dependency)
+
+InstantaneousDelayMachine{T,N}(f::Function, ninputs::Int, noutputs::Int, dependency = nothing) where {T,N} = 
+    InstantaneousDelayMachine{T,N}(ninputs, 0, noutputs, (u,x,h,p,t)->f(x), (u,x,h,p,t)->T[], dependency)
 
 InstantaneousDelayMachine{T}(m::DelayMachine{T, I}) where {T, I<:DirectedInterface{T}} = 
     DelayMachine{T}(InstantaneousDirectedInterface{T}(input_ports(m), output_ports(m), []), 
-                         DelayDirectedSystem{T}(nstates(m), dynamics(m), (u,x,p,t) -> readout(m, u, p, t))
+                         DelayDirectedSystem{T}(nstates(m), dynamics(m), (u,x,h,p,t) -> readout(m, u, p, t))
     )
   
 
@@ -309,16 +327,20 @@ eltype(::AbstractMachine{T}) where T = T
 readout(f::AbstractMachine, u::AbstractVector, p = nothing, t = 0) = readout(f)(u, p, t)
 readout(f::AbstractMachine, u::FinDomFunction, args...) = readout(f, collect(u), args...)
 
-readout(m::Machine{T,I,S}, u::AbstractVector, x::AbstractVector, p=nothing, t=0) where {T, I<:InstantaneousDirectedInterface{T}, S} = 
+readout(m::Machine{T,I,S}, u::AbstractVector, x::AbstractVector, p=nothing, t=0) where {T, I<:AbstractInstantaneousDirectedInterface{T}, S} = 
   readout(m)(u,x,p,t)
-readout(m::Machine{T,I,S}, u::AbstractVector, x::AbstractVector, p=nothing, t=0) where {T, I<:InstantaneousDirectedVectorInterface, S} = 
-  readout(m)(u,x,p,t)
+# readout(m::Machine{T,I,S}, u::AbstractVector, x::AbstractVector, p=nothing, t=0) where {T, I<:InstantaneousDirectedInterface{T}, S} = 
+#   readout(m)(u,x,p,t)
+# readout(m::Machine{T,I,S}, u::AbstractVector, x::AbstractVector, p=nothing, t=0) where {T, I<:InstantaneousDirectedVectorInterface, S} = 
+#   readout(m)(u,x,p,t)
 
 readout(f::DelayMachine{T,I}, u::AbstractVector, h=nothing, p = nothing, t = 0) where {T, I<:Union{DirectedInterface, DirectedVectorInterface}}= readout(f)(u, h, p, t)
-readout(m::DelayMachine{T,I}, u::AbstractVector, x::AbstractVector, h=nothing, p=nothing, t=0) where {T, I<:InstantaneousDirectedInterface} = 
+readout(m::DelayMachine{T,I}, u::AbstractVector, x::AbstractVector, h=nothing, p=nothing, t=0) where {T, I<:AbstractInstantaneousDirectedInterface} = 
   readout(m)(u,x,h,p,t)
-readout(m::DelayMachine{T,I}, u::AbstractVector, x::AbstractVector, h=nothing, p=nothing, t=0) where {T, I<:InstantaneousDirectedVectorInterface} = 
-  readout(m)(u,x,h,p,t)
+# readout(m::DelayMachine{T,I}, u::AbstractVector, x::AbstractVector, h=nothing, p=nothing, t=0) where {T, I<:InstantaneousDirectedInterface} = 
+#   readout(m)(u,x,h,p,t)
+# readout(m::DelayMachine{T,I}, u::AbstractVector, x::AbstractVector, h=nothing, p=nothing, t=0) where {T, I<:InstantaneousDirectedVectorInterface} = 
+#   readout(m)(u,x,h,p,t)
 
 """    eval_dynamics(m::AbstractMachine, u::AbstractVector, x:AbstractVector{F}, p, t) where {F<:Function}
     eval_dynamics(m::AbstractMachine{T}, u::AbstractVector, x:AbstractVector{T}, p, t) where T

--- a/src/dwd_dynam.jl
+++ b/src/dwd_dynam.jl
@@ -197,8 +197,8 @@ ContinuousMachine{T,I}(ninputs::Int, nstates::Int, dynamics) where {T,I} =
 ContinuousMachine{T,I}(ninputs, nstates, noutputs, dynamics, readout, dependency) where {T, I<:InstantaneousDirectedInterface{T}} = 
     ContinuousMachine{T, I}(I(ninputs, noutputs, dependency), ContinuousDirectedSystem{T}(nstates, dynamics, readout))
 
-InstantaneousContinuousMachine{T}(ninputs, nstates, noutputs, dynamics, readout, dependency) where {T, I <: AbstractDirectedInterface} = 
-    ContinuousMachine{T, I}(InstantaneousDirectedInterface{T}(ninputs, noutputs, dependency), ContinuousDirectedSystem{T}(nstates, dynamics, readout))
+InstantaneousContinuousMachine{T}(ninputs, nstates, noutputs, dynamics, readout, dependency) where {T} = 
+    ContinuousMachine{T, InstantaneousDirectedInterface{T}}(InstantaneousDirectedInterface{T}(ninputs, noutputs, dependency), ContinuousDirectedSystem{T}(nstates, dynamics, readout))
 
 InstantaneousContinuousMachine{T,N}(ninputs, nstates, noutputs, dynamics, readout, dependency) where {T,N} = 
     ContinuousMachine{T, InstantaneousDirectedVectorInterface{T,N}}(InstantaneousDirectedVectorInterface{T,N}(ninputs, noutputs, dependency), ContinuousDirectedSystem{T}(nstates, dynamics, readout))
@@ -206,7 +206,7 @@ InstantaneousContinuousMachine{T,N}(ninputs, nstates, noutputs, dynamics, readou
 InstantaneousContinuousMachine{T, I}(f::Function, ninputs::Int, noutputs::Int, dependency = nothing) where {T,I} = 
     InstantaneousContinuousMachine{T, I}(ninputs, 0, noutputs, (u,x,p,t)->T[], (u,x,p,t)->f(x), dependency)
 
-InstantaneousContinuousMachine{T, I}(m::ContinuousMachine{T, I}) where {T, I<:DirectedInterface{T}} = 
+InstantaneousContinuousMachine{T}(m::ContinuousMachine{T, I}) where {T, I<:DirectedInterface{T}} = 
     ContinuousMachine{T}(InstantaneousDirectedInterface{T}(input_ports(m), output_ports(m), []), 
                          ContinuousDirectedSystem{T}(nstates(m), dynamics(m), (u,x,p,t) -> readout(m, u, p, t))
     )
@@ -242,16 +242,16 @@ DelayMachine{T,I}(ninputs::Int, nstates::Int, dynamics) where {T,I}  =
 DelayMachine{T,I}(ninputs, nstates, noutputs, dynamics, readout, dependency) where {T, I<:InstantaneousDirectedInterface{T}} = 
     DelayMachine{T, I}(I(ninputs, noutputs, dependency), DelayDirectedSystem{T}(nstates, dynamics, readout))
 
-InstantaneousDelayMachine{T}(ninputs, nstates, noutputs, dynamics, readout, dependency) where T = 
-    DelayMachine{T}(InstantaneousDirectedInterface{T}(ninputs, noutputs, dependency), DelayDirectedSystem{T}(nstates, dynamics, readout))
+InstantaneousDelayMachine{T}(ninputs, nstates, noutputs, dynamics, readout, dependency) where {T} = 
+    DelayMachine{T, InstantaneousDirectedInterface{T}}(InstantaneousDirectedInterface{T}(ninputs, noutputs, dependency), DelayDirectedSystem{T}(nstates, dynamics, readout))
 
 InstantaneousDelayMachine{T,N}(ninputs, nstates, noutputs, dynamics, readout, dependency) where {T,N} = 
-    DelayMachine{T}(InstantaneousDirectedVectorInterface{T,N}(ninputs, noutputs, dependency), DelayDirectedSystem{T}(nstates, dynamics, readout))
+    DelayMachine{T,InstantaneousDirectedVectorInterface{T,N}}(InstantaneousDirectedVectorInterface{T,N}(ninputs, noutputs, dependency), DelayDirectedSystem{T}(nstates, dynamics, readout))
 
-InstantaneousDelayMachine{T}(f::Function, ninputs::Int, noutputs::Int, dependency = nothing) where T = 
-    InstantaneousDelayMachine{T}(ninputs, 0, noutputs, (u,x,p,t)->T[], (u,x,p,t)->f(x), dependency)
+InstantaneousDelayMachine{T, I}(f::Function, ninputs::Int, noutputs::Int, dependency = nothing) where {T,I} = 
+    InstantaneousDelayMachine{T, I}(ninputs, 0, noutputs, (u,x,p,t)->T[], (u,x,p,t)->f(x), dependency)
 
-InstantaneousDelayMachine(m::DelayMachine{T, I}) where {T, I<:DirectedInterface{T}} = 
+InstantaneousDelayMachine{T}(m::DelayMachine{T, I}) where {T, I<:DirectedInterface{T}} = 
     DelayMachine{T}(InstantaneousDirectedInterface{T}(input_ports(m), output_ports(m), []), 
                          DelayDirectedSystem{T}(nstates(m), dynamics(m), (u,x,p,t) -> readout(m, u, p, t))
     )

--- a/test/dwd_dynam.jl
+++ b/test/dwd_dynam.jl
@@ -315,14 +315,14 @@ end
     m = InstantaneousContinuousMachine{Float64,3}(
       1, 3, 1,
       (u, x, p, t) -> u*1.5, # dynamics
-      (u, x, p, t) -> u+x, # readout
+      (u, x, p, t) -> u+x[1], # readout
       [1 => 1]
     )
     
     x1 = Float64.([1,2,3])
     u1 = Float64.([4,5,6])
     
-    @test readout(m, u1, x1, nothing, 0) == u1+x1
+    @test readout(m, u1, [x1], nothing, 0) == u1+x1
     @test eval_dynamics(m, u1, [x1], nothing, 0) == u1*1.5
 
     # compare to analytic soln
@@ -355,7 +355,7 @@ end
     m = InstantaneousDelayMachine{Float64,3}(
       1, 3, 1, # ninputs, nstates, noutputs
       (u, x, h, p, t) -> -h(p, t-1), # dynamics
-      (u, x, h, p, t) -> u+x, # readout
+      (u, x, h, p, t) -> u+x[1], # readout
       [1 => 1] # output -> input dependency
     )
     
@@ -363,7 +363,7 @@ end
     u1 = Float64.([4,5,6])
     hist(p,t) = u1
     
-    @test readout(m, u1, x1, hist, nothing, 0)  == u1+x1
+    @test readout(m, u1, [x1], hist, nothing, 0)  == u1+x1
     @test eval_dynamics(m, u1, [x1], hist, nothing, 0) == -u1
     
     prob = DDEProblem(m, u1, [x1], hist, (0.0, 3.0), nothing)

--- a/test/dwd_dynam.jl
+++ b/test/dwd_dynam.jl
@@ -312,21 +312,23 @@ end
   end
 
   @testset "VectorInterface for InstantaneousContinuousMachine" begin
-    m1 = InstantaneousContinuousMachine{Float64,3}(
+    m = InstantaneousContinuousMachine{Float64,3}(
       1, 3, 1,
-      (u, x, p, t) -> x*1.5,
-      (u, x, p, t) -> u+x,
+      (u, x, p, t) -> u*1.5, # dynamics
+      (u, x, p, t) -> u+x, # readout
       [1 => 1]
     )
+    
+    x1 = Float64.([1,2,3])
+    u1 = Float64.([4,5,6])
+    
+    @test readout(m, u1, x1, nothing, 0) == u1+x1
+    @test eval_dynamics(m, u1, [x1], nothing, 0) == u1*1.5
 
-    x1 = [1,2,3]
-    u1 = [4,5,6]
-
-    @test readout(m1, u1, x1, nothing, 0) == u1+x1
-    @test eval_dynamics(m1, u1, [x1], nothing, 0) == x1*1.5
-
+    # compare to analytic soln
+    prob = ODEProblem(m, u1, [x1], (0.0, 0.05))
+    sol = solve(prob, Tsit5())
+    
+    @test sol.u[end] ≈ [x*exp(1.5*0.05) for x in u1]
   end
 end
-
-
-

--- a/test/dwd_dynam.jl
+++ b/test/dwd_dynam.jl
@@ -330,5 +330,27 @@ end
     sol = solve(prob, Tsit5())
     
     @test sol.u[end] ≈ [x*exp(1.5*0.05) for x in u1]
+
+    # check it composes
+    m1 = InstantaneousContinuousMachine{Float64,3}(2, 3, 1,
+      (u, x, p, t) -> x[1] + x[2],
+      (u,p,t) -> [u])
+    m2 = InstantaneousContinuousMachine{Float64, 3}(1, 3, 2,
+      (u, x, p, t) -> x[1] + u,
+      (u,p,t) -> [u, 2*u])
+    m3 = InstantaneousContinuousMachine{Float64, 3}(1, 3, 1,
+      (u, x, p, t) -> x[1],
+      (u,p,t) -> [u])
+    m = oapply(d_big, [m1, m2, m3])
+
+    u1 = 1:3; u2 = 4:6; u3 = 7:9;
+    x1 = ones(3); x2 = fill(0.5, 3)
+
+    @test readout(m, vcat(u1, u2, u3), nothing, 0) == [u1 + u2, u2, u3]
+    @test eval_dynamics(m, vcat(u1, u2, u3), [x1, x2], nothing, 0) == vcat(x1, u2 + x1 + 2*u2 + u3, x2)
+
   end
 end
+
+
+

--- a/test/dwd_dynam.jl
+++ b/test/dwd_dynam.jl
@@ -310,6 +310,22 @@ end
     @test readout(m, vcat(u1, u2, u3), nothing, 0) == [u1 + u2, u2, u3]
     @test eval_dynamics(m, vcat(u1, u2, u3), [x1, x2], nothing, 0) == vcat(x1, u2 + x1 + 2*u2 + u3, x2)
   end
+
+  @testset "VectorInterface for InstantaneousContinuousMachine" begin
+    m1 = InstantaneousContinuousMachine{Float64,3}(
+      1, 3, 1,
+      (u, x, p, t) -> x*1.5,
+      (u, x, p, t) -> u+x,
+      [1 => 1]
+    )
+
+    x1 = [1,2,3]
+    u1 = [4,5,6]
+
+    @test readout(m1, u1, x1, nothing, 0) == u1+x1
+    @test eval_dynamics(m1, u1, [x1], nothing, 0) == x1*1.5
+
+  end
 end
 
 


### PR DESCRIPTION
Adds a new interface `InstantaneousDirectedVectorInterface` for instantaneous machines that want to pass vectors along wires. Currently only working for Delay and Continuous machines.