### PR TITLE
Update compat for new Catlab version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["James Fairbanks", "Sophie Libkind"]
 version = "0.1.8"
 
 [deps]
+ACSets = "227ef7b5-1206-438b-ac65-934d6da304b8"
 Catlab = "134e5e36-593f-5add-ad60-77f754baafbe"
 Compose = "a81c6b42-2e10-5240-aca2-a61377ecd94b"
 DelayDiffEq = "bcd4f6db-9728-5f36-b5f7-82caef46ccdb"
@@ -19,7 +20,7 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
-Catlab = "0.11, 0.12, 0.13, 0.14"
+Catlab = "0.15"
 Compose = "^0.9.1"
 DelayDiffEq = "5"
 DifferentialEquations = "^6.16.0, 7"

--- a/src/AlgebraicDynamics.jl
+++ b/src/AlgebraicDynamics.jl
@@ -1,9 +1,6 @@
 module AlgebraicDynamics
 
 using Catlab
-using Catlab.Theories
-using Catlab.WiringDiagrams
-using Catlab.Programs
 
 include("uwd_dynam.jl")
 include("dwd_dynam.jl")

--- a/src/cpg_dynam.jl
+++ b/src/cpg_dynam.jl
@@ -1,10 +1,7 @@
 module CPortGraphDynam
 
-using Catlab.WiringDiagrams
-using Catlab.WiringDiagrams.CPortGraphs
-using  Catlab.CategoricalAlgebra
-using  Catlab.CategoricalAlgebra.FinSets
-using Catlab.Graphs
+using Catlab
+using ACSets
 import Catlab.Graphs: Graph
 using Catlab.Graphics.GraphvizGraphs: to_graphviz
 

--- a/src/dwd_dynam.jl
+++ b/src/dwd_dynam.jl
@@ -1,9 +1,7 @@
 module DWDDynam
 
-using Catlab.Theories
-using Catlab.WiringDiagrams.DirectedWiringDiagrams
-using Catlab.CategoricalAlgebra, Catlab.Graphs
-using Catlab.CategoricalAlgebra.FinSets
+using Catlab
+using ACSets
 import Catlab.WiringDiagrams: oapply, input_ports, output_ports
 
 import ..UWDDynam: AbstractInterface, nstates, eval_dynamics, euler_approx, trajectory

--- a/src/uwd_dynam.jl
+++ b/src/uwd_dynam.jl
@@ -1,9 +1,6 @@
 module UWDDynam
 using Catlab
-using Catlab.WiringDiagrams, Catlab.Programs
-using Catlab.CategoricalAlgebra
-using Catlab.CategoricalAlgebra.FinSets
-using Catlab.Theories
+using ACSets
 
 using Catlab.WiringDiagrams.UndirectedWiringDiagrams: AbstractUWD
 import Catlab.WiringDiagrams: oapply, ports

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,6 @@
 [deps]
 AlgebraicDynamics = "5fd6ff03-a254-427e-8840-ba658f502e32"
-AlgebraicPetri = "4f99eebe-17bf-4e98-b6a1-2c4f205a959b"
+ACSets = "227ef7b5-1206-438b-ac65-934d6da304b8"
 Catlab = "134e5e36-593f-5add-ad60-77f754baafbe"
 DelayDiffEq = "bcd4f6db-9728-5f36-b5f7-82caef46ccdb"
 LabelledArrays = "2ee39098-c373-598a-b85f-a56591580800"

--- a/test/cpg_dynam.jl
+++ b/test/cpg_dynam.jl
@@ -2,12 +2,8 @@ using AlgebraicDynamics.CPortGraphDynam
 using AlgebraicDynamics.DWDDynam
 using AlgebraicDynamics.CPortGraphDynam: draw, barbell, gridpath, grid, meshpath
 using AlgebraicDynamics.DWDDynam: trajectory
-using Catlab.WiringDiagrams
-using Catlab.WiringDiagrams.CPortGraphs
-using Catlab.CategoricalAlgebra
-using Catlab.Theories
-using Catlab.Graphs
 using Catlab
+using ACSets
 
 using DelayDiffEq
 using LabelledArrays

--- a/test/dwd_dynam.jl
+++ b/test/dwd_dynam.jl
@@ -1,5 +1,6 @@
 using AlgebraicDynamics.DWDDynam
-using Catlab.WiringDiagrams, Catlab.Present, Catlab.Theories, Catlab.Programs
+using Catlab
+using ACSets
 using LabelledArrays
 using DelayDiffEq
 using Test

--- a/test/trajectories.jl
+++ b/test/trajectories.jl
@@ -2,8 +2,8 @@ using AlgebraicDynamics
 using AlgebraicDynamics.UWDDynam
 using AlgebraicDynamics.DWDDynam
 
-using Catlab.WiringDiagrams
-using Catlab.CategoricalAlgebra
+using Catlab
+using ACSets
 
 using OrdinaryDiffEq
 

--- a/test/uwd_dynam.jl
+++ b/test/uwd_dynam.jl
@@ -1,8 +1,9 @@
 using AlgebraicDynamics.UWDDynam
-using Catlab.WiringDiagrams,  Catlab.Programs
+using Catlab
+using ACSets
 using DelayDiffEq
 using Test
-using AlgebraicPetri
+#using AlgebraicPetri
 
 const UWD = UndirectedWiringDiagram
 
@@ -252,7 +253,7 @@ end
   end
 end
 
-@testset "AlgebraicPetri" begin 
+#=@testset "AlgebraicPetri" begin 
   birth_petri = Open(PetriNet(1, 1=>(1,1)));
   rs = ContinuousResourceSharer{Float64}(birth_petri)
   @test nstates(rs) == 1
@@ -273,4 +274,4 @@ end
   @test nstates(rs) == 6
   @test nports(rs) == 4
   @test portmap(rs) == [1,3, 1,2]
-end
+end=#


### PR DESCRIPTION
This relies on the Catlab v0.15 release and also now depends ACSets. This PR probably shouldn't be merged until AlgPetri compat is bumped to Catlab v0.15 as well. Until then, I just commented out the tests that depend on AlgPetri.