### PR TITLE
Add steady state matrices.

### DIFF
--- a/src/AlgebraicDynamics.jl
+++ b/src/AlgebraicDynamics.jl
@@ -6,6 +6,7 @@ include("uwd_dynam.jl")
 include("dwd_dynam.jl")
 include("cpg_dynam.jl")
 include("ThresholdLinear/ThresholdLinear.jl")
+include("steady.jl")
 
 @reexport using .DWDDynam
 @reexport using .UWDDynam

--- a/src/steady.jl
+++ b/src/steady.jl
@@ -1,0 +1,66 @@
+module Steady
+
+export Machine, ss
+
+"""
+    Machine
+
+A discrete dynamical system is a quintuple ``(I, O, S, u, r)``, where
+
+  - ``I`` is a set of inputs
+  - ``O`` is a set of outputs
+  - ``S`` is a set of states
+  - ``u: I \\times S \\to S`` is an update function
+  - ``r: S \\to O`` is a readout function
+
+"""
+struct Machine
+    """
+        Uᵢⱼ = u(j, i)
+    """
+    U::Matrix{Int}
+    """
+        Rⱼ = r(j)
+    """
+    R::Vector{Int}
+end
+
+"""
+    ss(machine::Machine)
+
+Construct a matrix
+```math
+    S: O \\times I \\to \\mathbb{N}
+```
+whose entry ``S_{ij}`` contains the number of states ``s \\in S`` 
+such that
+
+  - ``u(j, s) = s`` and
+  - ``r(s) = i``.
+
+"""
+function ss(machine::Machine)
+    # update matrix
+    U = machine.U
+
+    # readout matrix
+    R = machine.R
+
+    # steady-state matrix
+    S = zeros(size(U))
+
+    for j in axes(U, 2)
+        for i in axes(U, 1)
+            k = R[i]
+            
+            if U[i, j] == i
+                # i is a (j, k) steady-state
+                S[k, j] += 1
+            end
+        end
+    end
+
+    return S
+end
+
+end


### PR DESCRIPTION
Example use.

```julia
using AlgebraicDynamics
using AlgebraicDynamics.Steady

n = 100

# disrete dynamical systems
M1 = Machine(rand(1:n, n, n), rand(1:n, n))
M2 = Machine(rand(1:n, n, n), rand(1:n, n))
M3 = Machine(rand(1:n, n, n), rand(1:n, n))

# steady-state matrices
S1 = ss(M1)
S2 = ss(M2)
S3 = ss(M3)

# compose steady-state matrices
S3 * S2 * S1
```

We can also compose the steady-state matrices using [WiringDiagrams.jl](https://github.com/AlgebraicJulia/WiringDiagrams.jl).

```julia
using WiringDiagrams, OMEinsum

# composition pattern
d = WiringDiagram([[1, 2], [2, 3], [3, 4]], [1, 4], Dict(1 => n, 2 => n, 3 => n, 4 => n))

# wiring diagram algebra
a = ArrayAlgebra{Array{Float64}}()

# compose steady-state matrices
a(d)(S3, S2, S1)
```